### PR TITLE
Code checks simplified 

### DIFF
--- a/bin/detect-tab-indent
+++ b/bin/detect-tab-indent
@@ -1,0 +1,43 @@
+#!/usr/bin/env python3
+import sys
+import os
+
+def detect_hardtabs(lines):
+    bad_lines = 0
+    for l in lines:
+        lstrip = l.lstrip()
+        l_ws = l[:len(l)-len(lstrip)]
+        
+        if '\t' in l_ws:
+            bad_lines += 1
+        
+    return bad_lines
+
+
+def process_file(input_file):
+    file_lines = []
+    with open(input_file, 'r') as f:
+        file_lines = [l.rstrip('\n') for l in f.readlines()]
+        
+    n = detect_hardtabs(file_lines) 
+    if n > 0:
+        print("%s: %d lines with hard tab indents found" % (input_file, n))
+        return True
+    return False
+
+def main():
+    if len(sys.argv) < 2:
+        print ('%s: no input files' % sys.argv[0])
+        return
+    print ('checking %d files...' % len(sys.argv[1:]))
+    bad_files = 0
+    for fi in sys.argv[1:]:
+        if os.path.exists(fi) and not os.path.isdir(fi):
+            if process_file(fi):
+                bad_files = 1
+        else:
+            print ("skipping non-existent path: %s" % fi)
+    sys.exit(bad_files)
+    
+if __name__ == '__main__':
+    main()

--- a/bin/detect-tab-indent
+++ b/bin/detect-tab-indent
@@ -29,7 +29,6 @@ def main():
     if len(sys.argv) < 2:
         print ('%s: no input files' % sys.argv[0])
         return
-    print ('checking %d files...' % len(sys.argv[1:]))
     bad_files = 0
     for fi in sys.argv[1:]:
         if os.path.exists(fi) and not os.path.isdir(fi):

--- a/bin/gh_pr_bootstrap.sh
+++ b/bin/gh_pr_bootstrap.sh
@@ -69,12 +69,12 @@ function print_jobinfo() {
 
 function setup_cmsbot() {
     source $HOME/PyGithub/bin/activate
-    export CMS_BOT_DIR="$WORKSPACE/cms-bot"
+    export CMS_BOT_DIR="$WORKSPACE/CI"
 
     if [ ! -d ${CMS_BOT_DIR} ]; then
         (
             cd "$WORKSPACE"
-            git clone -b master git@github.com:FNALbuild/cms-bot
+            git clone -b master git@github.com:Mu2e/CI
         )
     else
         (

--- a/bin/github/jenkins_tests/mu2e-offline-build-test/job.sh
+++ b/bin/github/jenkins_tests/mu2e-offline-build-test/job.sh
@@ -249,7 +249,7 @@ cat >> "$WORKSPACE"/gh-report.md <<- EOM
 | clang-tidy | ${CT_STATUS} | [${CT_STAT_STRING}](${JOB_URL}/${BUILD_NUMBER}/artifact/clang-tidy.log) |
 
 For more information, please check the job page [here](${JOB_URL}/${BUILD_NUMBER}/console).
-Build artefacts are deleted after 5 days. If this is not desired, select `Keep this build forever` on the job page.
+Build artefacts are deleted after 5 days. If this is not desired, select \`Keep this build forever\` on the job page.
 
 EOM
 

--- a/bin/github/jenkins_tests/mu2e-offline-build-test/job.sh
+++ b/bin/github/jenkins_tests/mu2e-offline-build-test/job.sh
@@ -249,6 +249,7 @@ cat >> "$WORKSPACE"/gh-report.md <<- EOM
 | clang-tidy | ${CT_STATUS} | [${CT_STAT_STRING}](${JOB_URL}/${BUILD_NUMBER}/artifact/clang-tidy.log) |
 
 For more information, please check the job page [here](${JOB_URL}/${BUILD_NUMBER}/console).
+Build artefacts are deleted after 5 days. If this is not desired, select `Keep this build forever` on the job page.
 
 EOM
 

--- a/bin/github/jenkins_tests/mu2e-offline-code-checks/checks.sh
+++ b/bin/github/jenkins_tests/mu2e-offline-code-checks/checks.sh
@@ -46,6 +46,7 @@ ${COMMIT_SHA}
 mu2e/codechecks
 success
 Code checks have finished.
+${JOB_URL}/${BUILD_NUMBER}/console
 NO_COMMENT
 
 EOM

--- a/bin/github/jenkins_tests/mu2e-offline-code-checks/checks.sh
+++ b/bin/github/jenkins_tests/mu2e-offline-code-checks/checks.sh
@@ -40,6 +40,41 @@ EOM
     exit 1;
 fi
 
+echo "[`date`] find hard tabs"
+HARD_TABS=0
+for MOD_FILE in $MODIFIED_PR_FILES
+do
+    if [[ "$MOD_FILE" == *.cc ]] || [[ "$MOD_FILE" == *.hh ]]; then
+        detect-tab-indent "$MOD_FILE" >> ${WORKSPACE}/detect-tab-indent-${COMMIT_SHA}.log
+        
+        if [ $? -ne 0 ]; then
+            HARD_TABS=1
+        fi
+    else
+        echo "skipped $MOD_FILE since not a cpp file"
+    fi
+done
+
+if [ $HARD_TABS -ne 0 ]; then
+  PURL="${JOB_URL}/${BUILD_NUMBER}/artifact/detect-tab-indent-${COMMIT_SHA}.log"
+  cat > $WORKSPACE/gh-report.md <<- EOM
+${COMMIT_SHA}
+mu2e/codechecks
+failure
+Hard tabs were found in one or more header or source files.
+${JOB_URL}/${BUILD_NUMBER}/console
+:cloud: Hard tab indentations were found at ${COMMIT_SHA} on files you changed.
+
+Please remove any tab characters from code indentations, and re-indent with spaces where appropriate. 
+
+See the [log file]($PURL) for more details.
+
+EOM
+
+    exit 1;
+fi
+
+
 
   cat > $WORKSPACE/gh-report.md <<- EOM
 ${COMMIT_SHA}

--- a/bin/github/jenkins_tests/mu2e-offline-code-checks/checks.sh
+++ b/bin/github/jenkins_tests/mu2e-offline-code-checks/checks.sh
@@ -47,7 +47,7 @@ mu2e/codechecks
 success
 Code checks have finished.
 ${JOB_URL}/${BUILD_NUMBER}/console
-NO_COMMENT
+NOCOMMENT
 
 EOM
 exit 0;

--- a/bin/github/jenkins_tests/mu2e-offline-code-checks/checks.sh
+++ b/bin/github/jenkins_tests/mu2e-offline-code-checks/checks.sh
@@ -4,14 +4,13 @@
 # 
 
 echo "[`date`] find trailing whitespace"
-CT_FILES="" # files to run in clang tidy
 PATCH_FILE="$WORKSPACE/codechecks-pr${PULL_REQUEST}-${COMMIT_SHA}.patch"
 for MOD_FILE in $MODIFIED_PR_FILES
 do
-    if [[ "$MOD_FILE" == *.cc ]] || [[ "$MOD_FILE" == *.hh ]]; then
+    if [[ "$MOD_FILE" == *.cc ]] || [[ "$MOD_FILE" == *.hh ]] || [[ "$MOD_FILE" == *.fcl ]]; then
         sed -Ei 's/[ \t]+$//' "$MOD_FILE"
     else
-        echo "skipped $MOD_FILE since not a cpp file"
+        echo "skipped $MOD_FILE since not a cpp or fcl file"
     fi
 done
 git diff > $PATCH_FILE
@@ -23,9 +22,9 @@ if [ -s "$PATCH_FILE" ]; then
 ${COMMIT_SHA}
 mu2e/codechecks
 failure
-Trailing whitespace was found in one or more header or source files.
+Trailing whitespace was found in one or more header, source, or fcl files.
 ${JOB_URL}/${BUILD_NUMBER}/console
-:cloud: Trailing whitespace characters were found at ${COMMIT_SHA} on files you changed.
+:x: Trailing whitespace characters were found at ${COMMIT_SHA} on files you changed.
 
 You can review the generated patch [here]($PURL).
 
@@ -44,7 +43,7 @@ echo "[`date`] find hard tabs"
 HARD_TABS=0
 for MOD_FILE in $MODIFIED_PR_FILES
 do
-    if [[ "$MOD_FILE" == *.cc ]] || [[ "$MOD_FILE" == *.hh ]]; then
+    if [[ "$MOD_FILE" == *.cc ]] || [[ "$MOD_FILE" == *.hh ]] || [[ "$MOD_FILE" == *.fcl ]]; then
         detect-tab-indent "$MOD_FILE" >> ${WORKSPACE}/detect-tab-indent-${COMMIT_SHA}.log
         
         if [ $? -ne 0 ]; then
@@ -61,9 +60,9 @@ if [ $HARD_TABS -ne 0 ]; then
 ${COMMIT_SHA}
 mu2e/codechecks
 failure
-Hard tabs were found in one or more header or source files.
+Hard tabs were found in one or more header, source, or fcl files.
 ${JOB_URL}/${BUILD_NUMBER}/console
-:cloud: Hard tab indentations were found at ${COMMIT_SHA} on files you changed.
+:x: Hard tab indentations were found at ${COMMIT_SHA} on files you changed.
 
 Please remove any tab characters from code indentations, and re-indent with spaces where appropriate. 
 
@@ -80,7 +79,7 @@ fi
 ${COMMIT_SHA}
 mu2e/codechecks
 success
-Code checks have finished.
+Code checks were successful.
 ${JOB_URL}/${BUILD_NUMBER}/console
 NOCOMMENT
 

--- a/bin/github/jenkins_tests/mu2e-offline-code-checks/checks.sh
+++ b/bin/github/jenkins_tests/mu2e-offline-code-checks/checks.sh
@@ -22,7 +22,7 @@ if [ -s "$PATCH_FILE" ]; then
   cat > $WORKSPACE/gh-report.md <<- EOM
 ${COMMIT_SHA}
 mu2e/codechecks
-failed
+failure
 Trailing whitespace was found in one or more header or source files.
 ${JOB_URL}/${BUILD_NUMBER}/console
 :cloud: Trailing whitespace characters were found at ${COMMIT_SHA} on files you changed.


### PR DESCRIPTION
Code checks now greatly simplified.

`sed` is used to remove trailing whitespace characters from `.cc` or `.hh` files. FNALbuild will complain if `sed` found/changed anything.
Provides a patch file as a quick remedy - particularly useful if there are lots and lots of trailing whitespace characters.
