### PR TITLE
removed g4test_03MT flag from offline-build-test

### DIFF
--- a/bin/github/jenkins_tests/mu2e-offline-build-test/job.sh
+++ b/bin/github/jenkins_tests/mu2e-offline-build-test/job.sh
@@ -156,7 +156,7 @@ echo "[$(date)] report outcome"
 
 TESTS_FAILED=0
 MU2E_POSTBUILDTEST_STATUSES=""
-declare -a ART_TESTJOBS=("ceSimReco" "g4test_03MT" "transportOnly" "PS" "g4study" "cosmicSimReco" "rootOverlaps" "g4surfaceCheck")
+declare -a ART_TESTJOBS=("ceSimReco" "transportOnly" "PS" "g4study" "cosmicSimReco" "rootOverlaps" "g4surfaceCheck")
 for i in "${ART_TESTJOBS[@]}"
 do
     STATUS_temp=":wavy_dash:"


### PR DESCRIPTION
Here is my PR which removes the g4test_03MT from the nightly offline build tests. I removed the g4test_03MT flag from L159 in /bin/github/jenkins_tests/mu2e-offline-build-test/job.sh