### PR TITLE
Cleanup CI

### DIFF
--- a/bin/github/jenkins_tests/mu2e-offline-build-test/build.sh
+++ b/bin/github/jenkins_tests/mu2e-offline-build-test/build.sh
@@ -1,8 +1,6 @@
 #!/bin/bash
 # Ryunosuke O'Neil, 2020
-# roneil@fnal.gov
-# ryunosuke.oneil@postgrad.manchester.ac.uk
-
+# Contact: @ryuwd on GitHub
 
 function do_setupstep() {
     source /cvmfs/fermilab.opensciencegrid.org/products/common/etc/setups
@@ -22,39 +20,64 @@ function do_buildstep() {
 }
 
 function do_runstep() {
-    if [ -f ".build-tests.sh" ]; then
-        source .build-tests.sh
-    else
-        declare -a JOBNAMES=("ceSimReco" "g4test_03MT" "transportOnly" "PS" "g4study" "cosmicSimReco")
-        declare -a FCLFILES=("Validation/fcl/ceSimReco.fcl" "Mu2eG4/fcl/g4test_03MT.fcl" "Mu2eG4/fcl/transportOnly.fcl" "JobConfig/beam/PS.fcl" "Mu2eG4/fcl/g4study.fcl" "Validation/fcl/cosmicSimReco.fcl")
-        declare -a NEVTS_TJ=("1" "10" "1" "1" "1" "1")
-    fi
-    
     arraylength=${#JOBNAMES[@]}
-
+    started=0
     for (( i=1; i<arraylength+1; i++ ));
     do
+      started=$((started+1))
       (
         JOBNAME=${JOBNAMES[$i-1]}
         FCLFILE=${FCLFILES[$i-1]}
+        NEVTS=${NEVTS_TJ[$i-1]}
 
         echo "[$(date)] ${JOBNAME} step. Output is being written to ${WORKSPACE}/${JOBNAME}.log"
         echo "Test: mu2e -n ${NEVTS_TJ[$i-1]} -c ${FCLFILE}" > "${WORKSPACE}/${JOBNAME}.log" 2>&1
         echo "Please see the EOF for job results." >> "${WORKSPACE}/${JOBNAME}.log" 2>&1
         echo "-----------------------------------" >> "${WORKSPACE}/${JOBNAME}.log" 2>&1
-
-        mu2e -n "${NEVTS_TJ[$i-1]}" -c "${FCLFILE}" >> "${WORKSPACE}/${JOBNAME}.log" 2>&1
+        mu2e -n "${NEVTS}" -c "${FCLFILE}" >> "${WORKSPACE}/${JOBNAME}.log" 2>&1
         RC=$?
 
         if [ ${RC} -eq 0 ]; then
           echo "++REPORT_STATUS_OK++" >> "${WORKSPACE}/${JOBNAME}.log"
+          touch ${WORKSPACE}/${JOBNAME}.log.SUCCESS
+          cat > gh-report-${JOBNAME}.md <<- EOM
+${COMMIT_SHA}
+mu2e/${JOBNAME}
+success
+mu2e -c ${FCLFILE} -n ${NEVTS} finished with return code ${RC}
+${JOB_URL}/${BUILD_NUMBER}/artifact/${JOBNAME}.log
+NOCOMMENT
+
+EOM
+        else
+          touch ${WORKSPACE}/${JOBNAME}.log.FAILED
+
+          cat > gh-report-${JOBNAME}.md <<- EOM
+${COMMIT_SHA}
+mu2e/${JOBNAME}
+failure
+mu2e -c ${FCLFILE} -n ${NEVTS_TJ[$i-1]} failed with return code ${RC}
+${JOB_URL}/${BUILD_NUMBER}/artifact/${JOBNAME}.log
+NOCOMMENT
+
+EOM
         fi
 
         echo "++RETURN CODE++ $RC" >> "${WORKSPACE}/${JOBNAME}.log"
 
         echo "[$(date)] ${JOBNAME} return code is ${RC}"
-
+        cmsbot_report gh-report-${JOBNAME}.md
       ) &
+
+      failed=$(ls -1 ${WORKSPACE} | { grep log.FAILED || true; } | wc -l)
+      finished=$(ls -1 ${WORKSPACE} | { grep log.SUCCESS || true; } | wc -l)
+      running=$((started - finished - failed))
+      while (( running >= MAX_TEST_PROCESSES )); do
+        sleep 90
+        failed=$(ls -1 ${WORKSPACE} | { grep log.FAILED || true; } | wc -l)
+        finished=$(ls -1 ${WORKSPACE} | { grep log.SUCCESS || true; } | wc -l)
+        running=$((started - finished - failed))
+      done
     done
 
     #wait;

--- a/bin/github/jenkins_tests/mu2e-offline-build-test/job.sh
+++ b/bin/github/jenkins_tests/mu2e-offline-build-test/job.sh
@@ -303,6 +303,10 @@ fi
 
 
 cmsbot_report "$WORKSPACE/gh-report.md"
+
+echo "[$(date)] cleaning up old gists"
+${CMS_BOT_DIR}/cleanup-old-gists
+
 wait;
 exit $BUILDTEST_OUTCOME;
 

--- a/bin/github/jenkins_tests/mu2e-offline-build-test/job.sh
+++ b/bin/github/jenkins_tests/mu2e-offline-build-test/job.sh
@@ -1,7 +1,23 @@
 #!/bin/bash
 # Ryunosuke O'Neil, 2020
-# roneil@fnal.gov
-# ryunosuke.oneil@postgrad.manchester.ac.uk
+# Contact: @ryuwd on GitHub
+
+
+# Configuration of test jobs to run directly after a successful build
+if [ -f ".build-tests.sh" ]; then
+    source .build-tests.sh
+else
+    # these arrays should have the same length
+    # name of the job
+    declare -a JOBNAMES=("ceSimReco" "g4test_03MT" "transportOnly" "PS" "g4study" "cosmicSimReco")
+    # the fcl file to run the job
+    declare -a FCLFILES=("Validation/fcl/ceSimReco.fcl" "Mu2eG4/fcl/g4test_03MT.fcl" "Mu2eG4/fcl/transportOnly.fcl" "JobConfig/beam/PS.fcl" "Mu2eG4/fcl/g4study.fcl" "Validation/fcl/cosmicSimReco.fcl")
+    # how many events?
+    declare -a NEVTS_TJ=("1" "10" "1" "1" "1" "1")
+
+    # how many of these tests to run in parallel at once
+    export MAX_TEST_PROCESSES=6
+fi
 
 cd "$WORKSPACE" || exit
 rm -f *.log
@@ -156,8 +172,7 @@ echo "[$(date)] report outcome"
 
 TESTS_FAILED=0
 MU2E_POSTBUILDTEST_STATUSES=""
-declare -a ART_TESTJOBS=("ceSimReco" "transportOnly" "PS" "g4study" "cosmicSimReco" "rootOverlaps" "g4surfaceCheck" "g4test_03MT")
-for i in "${ART_TESTJOBS[@]}"
+for i in "${JOBNAMES[@]}"
 do
     STATUS_temp=":wavy_dash:"
 
@@ -192,7 +207,7 @@ mu2e/buildtest
 failure
 The build is failing (${BUILDTYPE})
 ${JOB_URL}/${BUILD_NUMBER}/console
-:umbrella: The build is failing at ref ${COMMIT_SHA}.
+:umbrella: The build is failing at ${COMMIT_SHA}.
 
 \`\`\`
 ${ERROR_OUTPUT}
@@ -213,7 +228,7 @@ mu2e/buildtest
 failure
 The build succeeded, but other tests are failing.
 ${JOB_URL}/${BUILD_NUMBER}/console
-:umbrella: The tests failed for ref ${COMMIT_SHA}.
+:umbrella: The tests failed for ${COMMIT_SHA}.
 
 EOM
 
@@ -231,7 +246,7 @@ mu2e/buildtest
 success
 The tests passed.
 ${JOB_URL}/${BUILD_NUMBER}/console
-:sunny: The tests passed at ref ${COMMIT_SHA}.
+:sunny: The tests passed at ${COMMIT_SHA}.
 
 EOM
 
@@ -262,7 +277,7 @@ fi
 cat >> "$WORKSPACE"/gh-report.md <<- EOM
 
 For more information, please check the job page [here](${JOB_URL}/${BUILD_NUMBER}/console).
-Build artefacts are deleted after 5 days. If this is not desired, select \`Keep this build forever\` on the job page.
+Build artifacts are deleted after 5 days. If this is not desired, select \`Keep this build forever\` on the job page.
 
 EOM
 

--- a/bin/github/jenkins_tests/mu2e-offline-build-test/job.sh
+++ b/bin/github/jenkins_tests/mu2e-offline-build-test/job.sh
@@ -17,6 +17,10 @@ else
 
     # how many of these tests to run in parallel at once
     export MAX_TEST_PROCESSES=8
+    
+    export JOBNAMES
+    export FCLFILES
+    export NEVTS_TJ
 fi
 
 cd "$WORKSPACE" || exit

--- a/bin/github/jenkins_tests/mu2e-offline-build-test/job.sh
+++ b/bin/github/jenkins_tests/mu2e-offline-build-test/job.sh
@@ -16,7 +16,7 @@ else
     declare -a NEVTS_TJ=("1" "10" "1" "1" "1" "1")
 
     # how many of these tests to run in parallel at once
-    export MAX_TEST_PROCESSES=6
+    export MAX_TEST_PROCESSES=8
 fi
 
 cd "$WORKSPACE" || exit


### PR DESCRIPTION
An update to try and make the code easier to inherit + fix some things. I will lose access to jenkins later this year as my computing account expires, so this is an effort to address a few things before that happens and to hopefully tie off a few more loose ends.

Some fixes to FNALbuild CI scripts
- delete up to 5 gists older than 30 days at the end of a build-test job
  - There are lots of gists on the FNALbuild account now, need to deal with them 
- fix spelling and remove erroneous use of term "ref" in result comments
- limit concurrency of test jobs that run after successful build (max processes is set to 8 at any one time)
  - this is more scalable i.e. if lots of FCLs are added to the tests then they won't all run at the same time (which may fill up memory and cause OOM crashes)
- move configuration of test jobs to the start of `job.sh`
  - added comments to aid understanding
  - only 3 arrays need to be changed now
  - all in all, easier to configure which tests to run, with what FCL file. Hopefully people can take advantage of this by adding their own tests
```bash
      # name of the job
    declare -a JOBNAMES=("ceSimReco" "g4test_03MT" "transportOnly" "PS" "g4study" "cosmicSimReco")
    # the fcl file to run the job
    declare -a FCLFILES=("Validation/fcl/ceSimReco.fcl" "Mu2eG4/fcl/g4test_03MT.fcl" "Mu2eG4/fcl/transportOnly.fcl" "JobConfig/beam/PS.fcl" "Mu2eG4/fcl/g4study.fcl" "Validation/fcl/cosmicSimReco.fcl")
    # how many events?
    declare -a NEVTS_TJ=("1" "10" "1" "1" "1" "1")

    # how many of these tests to run in parallel at once
    export MAX_TEST_PROCESSES=8
```
- changed my contact info 
- sends test status to GitHub as soon as it's available
