### PR TITLE
"Test with" feature

### DIFF
--- a/bin/gh_pr_bootstrap.sh
+++ b/bin/gh_pr_bootstrap.sh
@@ -155,53 +155,6 @@ function setup_offline() {
 }
 
 
-function offline_domerge() {
-    if [ "${NO_MERGE}" = "1" ]; then 
-        echo "[$(date)] Checking out PR HEAD directly"
-        git checkout "pr${PULL_REQUEST}"
-    else
-        echo "[$(date)] Checking out latest commit on base branch"
-        git checkout ${MASTER_COMMIT_SHA}
-    fi
-
-    if [ "${TEST_WITH_PR}" != "" ]; then
-        # comma separated list
-
-        for pr in $(echo ${TEST_WITH_PR} | sed "s/,/ /g")
-        do
-            git fetch origin pull/${pr}/head:pr${pr}
-            echo "[$(date)] Merging PR#${pr} as part of this test."
-            # Merge it in
-            git merge --no-ff pr${pr} -m "merged PR#${pr} as part of this test"
-            if [ "$?" -gt 0 ]; then
-                echo "[$(date)] Merge failure!"
-                return 1;
-            fi
-            CONFLICTS=$(git ls-files -u | wc -l)
-            if [ "$CONFLICTS" -gt 0 ] ; then
-                echo "[$(date)] Merge conflicts!"
-                return 1
-            fi
-        done
-    fi
-
-    if [ "${NO_MERGE}" != "1" ]; then 
-        echo "[$(date)] Merging PR#${pr} at ${COMMIT_SHA}."
-        git merge --no-ff ${COMMIT_SHA} -m "merged ${REPOSITORY} PR#${PULL_REQUEST} ${COMMIT_SHA}."
-
-        if [ "$?" -gt 0 ]; then
-            return 1;
-        fi
-
-        CONFLICTS=$(git ls-files -u | wc -l)
-        if [ "$CONFLICTS" -gt 0 ] ; then
-            return 1
-        fi
-    fi
-
-    return 0
-
-}
 
 echo "Running job now."
 

--- a/bin/github/jenkins_tests/mu2e-offline-build-test/job.sh
+++ b/bin/github/jenkins_tests/mu2e-offline-build-test/job.sh
@@ -15,7 +15,7 @@ function prepare_repositories() {
         cd $REPO
         if [ "${NO_MERGE}" = "1" ]; then 
             echo "[$(date)] Mu2e/$REPO - Checking out PR HEAD directly"
-            git checkout "pr${PULL_REQUEST}"
+            git checkout ${COMMIT_SHA} #"pr${PULL_REQUEST}"
             git log -1
             append_report_row "checkout" ":white_check_mark:" "Checked out ${COMMIT_SHA}"
         else
@@ -39,12 +39,15 @@ function prepare_repositories() {
                     REPO_NAME=$( echo $pr | awk -F\# '{print $1}' )
 	                THE_PR=$( echo $pr | awk -F\# '{print $2}' )
 
-                    # check it exists
+                    # check it exists, and clone it into the workspace if it does not.
                     if [ ! -d "$WORKSPACE/$REPO_NAME" ]; then 
-                        exit 1; # press F to pay respects
+                        (
+                            cd $WORKSPACE
+                            git clone git@github.com:Mu2e/${REPO_NAME}.git ${REPO_NAME} || exit 1
+                        ) || exit 1
                     fi
                     # change directory to it
-                    cd $WORKSPACE/$REPO_NAME || exit 1;
+                    cd $WORKSPACE/$REPO_NAME || exit 1
                 else
                     # ???
                     exit 1;


### PR DESCRIPTION
This PR lays the groundwork to make it possible to include other PRs in tests. It will not work straightaway until I merge another branch in Mu2e/CI.

#### How does it work?

If a PR in Offline depends on another PR to work, one can ask FNALbuild to include it in the test. e.g. if an un-merged PR #2 needs an un-merged PR #1
```
@FNALbuild run build test with #1 
```

This checks out Offline at the latest commit, does a merge of #1 followed by the usual merge of #2, and runs the tests as normal.  Effectively, this happens:
```
cd Offline
git checkout $(git rev-parse HEAD)
git fetch origin pull/2/head:pr2 # fetch PR2 branch from github
git fetch origin pull/1/head:pr1 # fetch PR1 branch from github

git merge pr1 # merge pr 1
git merge ${COMMIT_TO_BE_TESTED} # merge pr 2
```

This would also work with other Mu2e repositories e.g.
```
@FNALbuild run build test with Mu2e/Production#1, Mu2e/Offline#1
```

~~Even more useful, this can work with the `codetools` repository even if it is not a muse repo, meaning one doesn't have to test codetools changes in production anymore.~~
```
@FNALbuild run build test with Mu2e/codetools#999
```

One can also run a test without testing the "merged result" of the PR, i.e. just check out the PR branch directly.
```
@FNALbuild run build test without merge
```