### PR TITLE
merge build-with PRs into the right branch

### DIFF
--- a/bin/gh_pr_bootstrap.sh
+++ b/bin/gh_pr_bootstrap.sh
@@ -138,6 +138,16 @@ function cmsbot_report_test_status() {
         --url "$4"
 }
 
+function cmsbot_write_pr_base() {
+    # args: $1 is repo, $2 is pr number, $3 is the sha file name
+    # example: cmsbot_write_pr_base Mu2e/Offline 581 repoOffline_pr581_baseSha.txt
+    if [ "${CMS_BOT_VENV_SOURCED}" -ne 1 ]; then
+        CMS_BOT_VENV_SOURCED=1
+        source $HOME/mu2e-gh-bot-venv/bin/activate
+    fi
+    ${CMS_BOT_DIR}/get-pr-base-sha -r $1 -p $2 -f $3
+}
+
 
 function setup_build_repos() {
     # setup_build_repos Mu2e/Offline if you are testing Offline

--- a/bin/github/jenkins_tests/mu2e-offline-build-test/job.sh
+++ b/bin/github/jenkins_tests/mu2e-offline-build-test/job.sh
@@ -21,7 +21,7 @@ function prepare_repositories() {
         git log -1
         append_report_row "checkout" ":white_check_mark:" "Checked out ${COMMIT_SHA}"
     else
-        echo "[$(date)] Mu2e/$REPO - Checking out latest commit on base branch"
+        echo "[$(date)] Mu2e/$REPO - Checking out latest commit on base branch, which is ${MASTER_COMMIT_SHA}"
         git checkout ${MASTER_COMMIT_SHA}
         git log -1
     fi
@@ -62,6 +62,22 @@ function prepare_repositories() {
             git config user.email "you@example.com"
             git config user.name "Your Name"
             git fetch origin pull/${THE_PR}/head:pr${THE_PR}
+
+            # get the base ref commit sha for the test-with PR, but ONLY if it's in a different repo than the "overall" PR we're testing.
+            if [ ${REPO_NAME} != ${REPO} ]; then
+                REPO_NAME_NOOWNER=$( echo $REPO_NAME | awk -F/ '{print $2}' )
+                SHA_FILE_NAME="repo${REPO_NAME_NOOWNER}_pr${THE_PR}_baseSha.txt"
+                cmsbot_write_pr_base $REPO_NAME $THE_PR $SHA_FILE_NAME || echo "Failed to retrieve base branch commit sha for repo ${REPO_NAME} PR ${THE_PR}"
+                if [ -f $SHA_FILE_NAME ]; then
+                    THE_BASE_SHA=$(cat $SHA_FILE_NAME)
+                    echo "Checking out commit ${THE_BASE_SHA} on repo ${REPO_NAME} before merging PR ${THE_PR}"
+                    git checkout ${THE_BASE_SHA} || echo "Failed to checkout commit ${THE_BASE_SHA}, default is to merge into main"
+                    git log -1
+                else
+                    echo "No base commit sha file written for ${REPO_NAME}#${THE_PR}, default base is main branch"
+                    append_report_row "test with" ":x:" "Failed to retrieve request base branch commit sha for Mu2e/${REPO_NAME}#${THE_PR}, default is to merge into main"
+                fi
+            fi
 
             echo "[$(date)] Merging PR ${REPO_NAME}#${THE_PR} into ${REPO_NAME} as part of this test."
 


### PR DESCRIPTION
If a build test is run on a PR using "build with", and the build-with PR is in a different repo, then this will find the base branch (that is, the branch the build-with PR is requesting to be merged into) and check out the commit sha for that. Then it will do the merge for the build-with PR.