### PR TITLE
add new trig repo as default part of all CI builds

### DIFF
--- a/bin/gh_pr_bootstrap.sh
+++ b/bin/gh_pr_bootstrap.sh
@@ -8,7 +8,7 @@ DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" >/dev/null 2>&1 && pwd )"
 export JENKINS_TESTS_DIR="$DIR/github/jenkins_tests"
 export CLANGTOOLS_UTIL_DIR="$DIR/../clangtools_utilities"
 export TESTSCRIPT_DIR="$JENKINS_TESTS_DIR/$1"
-export REQUIRED_BUILD_REPOS_SHORT=("Offline" "Production")
+export REQUIRED_BUILD_REPOS_SHORT=("Offline" "Production" "mu2e_trig_config")
 export GH_COMMON_SCRIPT="$DIR/github/github_common.sh"
 
 # if the PR is trying to merge into this branch, make sure all other repos


### PR DESCRIPTION
All CI builds have been building with Offline and Production, now they will all build with mu2e_trig_config too.  This is necessary since some validation fcl will soon require pieces from the new repo.