### PR TITLE
try al9/spack version in phase 2

### DIFF
--- a/bin/github/jenkins_tests/mu2e-offline-build-test/build.sh
+++ b/bin/github/jenkins_tests/mu2e-offline-build-test/build.sh
@@ -3,10 +3,15 @@
 # Contact: @ryuwd on GitHub
 
 function do_setupstep() {
-    source /cvmfs/fermilab.opensciencegrid.org/products/common/etc/setups
-    setup mu2e
-    setup muse
-    setup codetools
+
+    source /cvmfs/mu2e.opensciencegrid.org/setupmu2e-art.sh
+    if [ "$MU2E_SPACK" ]; then
+        HH=$(spack find --format "{version} {hash:7}" codetools | sort -rn | head -1 | awk '{print $2}' )
+        echo "[$(date)] found codetools hash $HH"
+        spack load codetools/$HH || exit 1
+    else
+        setup codetools
+    fi
 
     # building prof or debug
     muse setup -q $BUILDTYPE


### PR DESCRIPTION
This commit attempts to change nothing when running on sl7. When running on al9, it uses spack as necessary, but in phase 2 style (muse/scons+spack).  On a day when Rob and I are available, we can merge this and check that is still runs ok on sl7.  Then switch the CI to al9 (ALMA9 in jenkins) and test that.  Then I think I see ways we can simplify the script with a few edits, so we should do that while we are at it.  I believe the githubCI runs these scripts from the head of this repo.