### PR TITLE
Removed most debugging printout and retained just the minimum.

### DIFF
--- a/bin/github/jenkins_tests/mu2e-offline-build-test/build.sh
+++ b/bin/github/jenkins_tests/mu2e-offline-build-test/build.sh
@@ -6,20 +6,16 @@ function do_setupstep() {
 
     source /cvmfs/mu2e.opensciencegrid.org/setupmu2e-art.sh
     if [ "$MU2E_SPACK" ]; then
-        echo "[$(date)]  Check run-clang-tidy " `command -v run-clang-tidy`
         HH=$(spack find --format "{version} {hash:7}" codetools | sort -rn | head -1 | awk '{print $2}' )
         echo "[$(date)] found codetools hash $HH"
         spack load codetools/$HH || exit 1
         unset HH
 
-        echo "[$(date)] spack load llvm/ztl5ab2 " `command -v clang-tidy`
         H1=$(spack find --format "{version} {hash:7}" llvm | sort -rn | head -1 | awk '{print $2}' )
         echo "[$(date)] found llvm hash $H1"
         spack load llvm/$H1 || exit 1
         unset H1
 
-        echo "[$(date)] spack load llvm/"$H1" - success " `command -v clang-tidy`
-        echo "[$(date)] clang-tidy --version" `clang-tidy --version`
     else
         setup codetools
     fi

--- a/bin/github/jenkins_tests/mu2e-offline-build-test/job.sh
+++ b/bin/github/jenkins_tests/mu2e-offline-build-test/job.sh
@@ -192,25 +192,12 @@ else
         if [ "$MU2E_SPACK" ]; then
 
             source /cvmfs/mu2e.opensciencegrid.org/setupmu2e-art.sh
-            echo "[$(date)] testing1 for clang tidy: " `command -v clang-tidy`
             H1=$(spack find --format "{version} {hash:7}" llvm | sort -rn | head -1 | awk '{print $2}' )
             echo "[$(date)] clang-tidy step found llvm hash $H1"
             spack load llvm/$H1 || exit 1
             unset H1
             muse setup -q $BUILDTYPE
 
-
-            #if ! command -v clang-tidy >/dev/null ; then
-            #    spack load llvm/ztl5ab2 || exit 1
-            #fi
-            echo "[$(date)] testing2 for clang tidy: " `command -v clang-tidy`
-            echo "[$(date)] BUILDTYPE:               "  ${BUILDTYPE}
-            echo "[$(date)] MUSE_BUILD_DIR:          "  ${MUSE_BUILD_DIR}
-            echo "[$(date)] MUSE_BUILD_BASE:         "  ${MUSE_BUILD_BASE}
-            echo "[$(date)] CT_FILES:                "  ${CT_FILES}
-            echo "[$(date)] clang-tidy --version" `clang-tidy --version`
-            #cp build/*/compile_commands.json .
-            #run-clang-tidy ${CT_FILES} > $WORKSPACE/clang-tidy.log || exit 1
             run-clang-tidy -p $MUSE_BUILD_DIR ${CT_FILES} > $WORKSPACE/clang-tidy.log || exit 1
 
         else


### PR DESCRIPTION
Compare to SHA 509c0e3 to see the net changes after all debugging.  The changes are: 

bin/github/jenkins_tests/mu2e-offline-build-test/build.sh
  - load the highest version spack available BEFORE "muse setup"
  - print the hash of the version that was found

bin/github/jenkins_tests/mu2e-offline-build-test/job.sh
  - Need to create the full environment, just like in build.sh 
  - Note that on entry clang-tidy is defined as /usr/bin/clang-tidy so the old test failed.
 

