### PR TITLE
Added muenv script for Python env activatation/deactivation

### DIFF
--- a/archive/muenv.sh
+++ b/archive/muenv.sh
@@ -66,7 +66,7 @@ if [ ! -f "$ACTIVATE_PATH" ]; then
 fi
 
 # Activate the environment
-echo "Activating Mu2e Python environment: $ENVNAME version $VERSION"
+echo "Activating Mu2e Python environment: $ENVNAME $VERSION"
 source "$ACTIVATE_PATH"
 
 # Setup deactivate 

--- a/archive/muenv.sh
+++ b/archive/muenv.sh
@@ -1,0 +1,96 @@
+#!/bin/bash
+#
+# Script to activate a Mu2e Python environment from /cvfms 
+#
+
+muenvUsage() {
+    cat << EOF
+
+    Usage: muse activate ENV_NAME [VERSION]
+
+    Activates a Mu2e Python environment.
+    
+    Available environments:
+      • ana     - Standard analysis environment
+      • rootana - Analysis environment with pyROOT support
+    
+    Parameters:
+      ENV_NAME - Required: Environment name ('ana' or 'rootana')
+      VERSION  - Optional: Environment version (default: 'current')
+    
+    Examples:
+      muenv ana
+      muenv rootana 1.2.0
+      
+    The first example runs:
+      source /cvmfs/mu2e.opensciencegrid.org/env/ana/current/bin/activate
+
+    See https://mu2ewiki.fnal.gov/wiki/Elastic_Analysis_Facility_(EAF)#Change_log for version info 
+
+    <command options>
+        -h, --help  : print usage
+
+EOF
+    return
+}
+
+# Show usage information if -h or no args
+if [[ "$1" == "-h" || "$1" == "--help" || "$1" == "help" || $# -eq 0 ]]; then
+    muenvUsage
+    return 0
+fi
+
+# Parse command line arguments
+ENVNAME=""
+VERSION=""
+
+# Get the environment name and version from args
+ENVNAME=$1
+VERSION=${2:-current}  # Use 'current' as default if $2 is not provided
+
+# Path to the activate/deactive scripts
+SCRIPT_PATH="${MU2E}/env/${ENVNAME}/${VERSION}/bin"
+ACTIVATE_PATH="${SCRIPT_PATH}/activate"
+DEACTIVATE_PATH="${SCRIPT_PATH}/deactivate"
+
+# Export variables so they're available to child processes (deactivate)
+export MUENV_NAME="$ENVNAME"
+export MUENV_VERSION="$VERSION"
+export MUENV_SCRIPT_PATH="$SCRIPT_PATH"
+
+# Check if the activate script exists
+if [ ! -f "$ACTIVATE_PATH" ]; then
+    echo "ERROR - activate script not found!"
+    echo "Path: $ACTIVATE_PATH"
+    return 1
+fi
+
+# Activate the environment
+echo "Activating Mu2e Python environment: $ENVNAME version $VERSION"
+source "$ACTIVATE_PATH"
+
+# Setup deactivate 
+deactivate() {
+    if [ -f "$DEACTIVATE_PATH" ]; then
+        source "$DEACTIVATE_PATH"
+    else
+        echo "WARNING: deactivate script not found at $DEACTIVATE_PATH"
+        # Fall back to Python's deactivate if available
+        if type python_deactivate >/dev/null 2>&1; then
+            python_deactivate
+        fi
+    fi
+    
+    # Unset environment variables
+    unset MUENV_NAME
+    unset MUENV_VERSION
+    unset MUENV_SCRIPT_PATH
+    
+    # Unset this function
+    unset -f deactivate
+}
+
+echo "Run 'deactivate' to exit the environment" 
+
+# Return success
+return 0

--- a/archive/pyenv.sh
+++ b/archive/pyenv.sh
@@ -3,7 +3,7 @@
 # Script to activate a Mu2e Python environment from /cvfms 
 #
 
-muenvUsage() {
+pyenvUsage() {
     cat << EOF
 
     Usage: muse activate ENV_NAME [VERSION]
@@ -19,8 +19,8 @@ muenvUsage() {
       VERSION  - Optional: Environment version (default: 'current')
     
     Examples:
-      muenv ana
-      muenv rootana 1.2.0
+      pyenv ana
+      pyenv rootana 1.2.0
       
     The first example runs:
       source /cvmfs/mu2e.opensciencegrid.org/env/ana/current/bin/activate
@@ -36,9 +36,12 @@ EOF
 
 # Show usage information if -h or no args
 if [[ "$1" == "-h" || "$1" == "--help" || "$1" == "help" || $# -eq 0 ]]; then
-    muenvUsage
+    pyenvUsage
     return 0
 fi
+
+# Unset the help function 
+unset -f pyenvUsage 
 
 # Parse command line arguments
 ENVNAME=""
@@ -54,9 +57,9 @@ ACTIVATE_PATH="${SCRIPT_PATH}/activate"
 DEACTIVATE_PATH="${SCRIPT_PATH}/deactivate"
 
 # Export variables so they're available to child processes (deactivate)
-export MUENV_NAME="$ENVNAME"
-export MUENV_VERSION="$VERSION"
-export MUENV_SCRIPT_PATH="$SCRIPT_PATH"
+export pyenv_NAME="$ENVNAME"
+export pyenv_VERSION="$VERSION"
+export pyenv_SCRIPT_PATH="$SCRIPT_PATH"
 
 # Check if the activate script exists
 if [ ! -f "$ACTIVATE_PATH" ]; then
@@ -82,9 +85,9 @@ deactivate() {
     fi
     
     # Unset environment variables
-    unset MUENV_NAME
-    unset MUENV_VERSION
-    unset MUENV_SCRIPT_PATH
+    unset pyenv_NAME
+    unset pyenv_VERSION
+    unset pyenv_SCRIPT_PATH
     
     # Unset this function
     unset -f deactivate

--- a/archive/setupmu2e-art.sh
+++ b/archive/setupmu2e-art.sh
@@ -85,5 +85,5 @@ export JOBSUB_GROUP=mu2e
 
 # Function for Python environment activatation 
 muenv() {
-  source muenv.sh
+  source "/cvmfs/mu2e.opensciencegrid.org/bin/pyenv.sh"
 }

--- a/archive/setupmu2e-art.sh
+++ b/archive/setupmu2e-art.sh
@@ -82,3 +82,8 @@ export JOBSUB_GROUP=mu2e
 
 # make sure the default man paths are included (path starts with ":")
 [ "${MANPATH:0:1}" != ":" ] && export MANPATH=":"$MANPATH
+
+# Function for Python environment activatation 
+muenv() {
+  source muenv.sh
+}

--- a/archive/setupmu2e-art.sh
+++ b/archive/setupmu2e-art.sh
@@ -84,6 +84,6 @@ export JOBSUB_GROUP=mu2e
 [ "${MANPATH:0:1}" != ":" ] && export MANPATH=":"$MANPATH
 
 # Function for Python environment activatation 
-muenv() {
+pyenv() {
   source "/cvmfs/mu2e.opensciencegrid.org/bin/pyenv.sh"
 }


### PR DESCRIPTION
Added script `muenv.sh` to easily activate and deactivate the Mu2e Python environment, followings Ray's recommendation. 

Demo:

```
[sgrant@mu2egpvm06 archive]$ source setupmu2e-art.sh 
[sgrant@mu2egpvm06 archive]$ muenv

    Usage: muse activate ENV_NAME [VERSION]

    Activates a Mu2e Python environment.
    
    Available environments:
      • ana     - Standard analysis environment
      • rootana - Analysis environment with pyROOT support
    
    Parameters:
      ENV_NAME - Required: Environment name ('ana' or 'rootana')
      VERSION  - Optional: Environment version (default: 'current')
    
    Examples:
      muenv ana
      muenv rootana 1.2.0
      
    The first example runs:
      source /cvmfs/mu2e.opensciencegrid.org/env/ana/current/bin/activate

    See https://mu2ewiki.fnal.gov/wiki/Elastic_Analysis_Facility_(EAF)#Change_log for version info 

    <command options>
        -h, --help  : print usage

[sgrant@mu2egpvm06 archive]$ muenv ana
Activating Mu2e Python environment: ana current
Run 'deactivate' to exit the environment
(current) [sgrant@mu2egpvm06 archive]$ deactivate
[sgrant@mu2egpvm06 archive]$ muenv rootana 1.2.0
Activating Mu2e Python environment: rootana 1.2.0
Run 'deactivate' to exit the environment
(1.2.0) [sgrant@mu2egpvm06 archive]$ deactivate
[sgrant@mu2egpvm06 archive]$ 
```

Note: I included the child `deactivate` function, since the in-built `deactivate` returns `Permission denied`. 

Please let me know what you think. 